### PR TITLE
feat(coordinator): check for token expiration before refresh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
     "homeassistant==2025.5.0",
     "ruff==0.13.3",
     "pre-commit-uv>=4.1.5",
+    "pyjwt>=2.10.0",
 ]
 
 [tool.coverage.run]

--- a/tests/test_coordinator_is_token_expired.py
+++ b/tests/test_coordinator_is_token_expired.py
@@ -1,0 +1,36 @@
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from custom_components.edilkamin.coordinator import EdilkaminCoordinator
+
+
+class DummyHass:
+    async def async_add_executor_job(self, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+def make_token(exp_offset_sec):
+    # Generate a JWT token with a custom expiration time
+    payload = {"exp": int((datetime.now(UTC) + timedelta(seconds=exp_offset_sec)).timestamp())}  # noqa: E501
+    return jwt.encode(payload, key="secret", algorithm="HS256")
+
+def test_is_token_expired_expired():
+    coordinator = EdilkaminCoordinator(DummyHass(), "user", "pass", "mac")
+    expired_token = make_token(-10)  # Expired token since 10s
+    assert coordinator.is_token_expired(expired_token) is True
+
+def test_is_token_expired_valid():
+    coordinator = EdilkaminCoordinator(DummyHass(), "user", "pass", "mac")
+    valid_token = make_token(3600)  # Expires in 1h
+    assert coordinator.is_token_expired(valid_token) is False
+
+def test_is_token_expired_no_exp():
+    coordinator = EdilkaminCoordinator(DummyHass(), "user", "pass", "mac")
+    # Token without exp field
+    token = jwt.encode({}, key="secret", algorithm="HS256")
+    assert coordinator.is_token_expired(token) is True
+
+def test_is_token_expired_invalid():
+    coordinator = EdilkaminCoordinator(DummyHass(), "user", "pass", "mac")
+    # Undecodable token
+    assert coordinator.is_token_expired("not.a.jwt") is True

--- a/tests/test_coordinator_refresh_token.py
+++ b/tests/test_coordinator_refresh_token.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.edilkamin.coordinator import EdilkaminCoordinator
+
+
+class DummyHass:
+    async def async_add_executor_job(self, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+def fake_sign_in(*_args, **_kwargs):
+    return "new_token.jwt"
+
+
+@pytest.mark.asyncio
+@patch("custom_components.edilkamin.coordinator.edilkamin.sign_in",
+       side_effect=fake_sign_in)
+async def test_refresh_token_none(mock_sign_in):
+    coordinator = EdilkaminCoordinator(DummyHass(), "user", "pass", "mac")
+    coordinator._token = None
+    token = await coordinator.refresh_token()
+    assert token == "new_token.jwt"  # noqa: S105
+    assert coordinator._token == "new_token.jwt"  # noqa: S105
+    mock_sign_in.assert_called_once_with("user", "pass")
+
+
+@pytest.mark.asyncio
+@patch("custom_components.edilkamin.coordinator.edilkamin.sign_in",
+       side_effect=fake_sign_in)
+@patch("custom_components.edilkamin.coordinator.EdilkaminCoordinator.is_token_expired",
+       return_value=True)
+async def test_refresh_token_expired(mock_is_expired, mock_sign_in):
+    coordinator = EdilkaminCoordinator(DummyHass(), "user", "pass", "mac")
+    coordinator._token = "expired.jwt"  # noqa: S105
+    token = await coordinator.refresh_token()
+    assert token == "new_token.jwt"  # noqa: S105
+    assert coordinator._token == "new_token.jwt"  # noqa: S105
+    mock_sign_in.assert_called_once_with("user", "pass")
+    mock_is_expired.assert_called_once_with("expired.jwt")
+
+
+@pytest.mark.asyncio
+@patch("custom_components.edilkamin.coordinator.edilkamin.sign_in",
+       side_effect=fake_sign_in)
+@patch("custom_components.edilkamin.coordinator.EdilkaminCoordinator.is_token_expired",
+       return_value=False)
+async def test_refresh_token_valid(mock_is_expired, mock_sign_in):
+    coordinator = EdilkaminCoordinator(DummyHass(), "user", "pass", "mac")
+    coordinator._token = "valid.jwt"  # noqa: S105
+    token = await coordinator.refresh_token()
+    assert token == "valid.jwt"  # noqa: S105
+    assert coordinator._token == "valid.jwt"  # noqa: S105
+    mock_sign_in.assert_not_called()
+    mock_is_expired.assert_called_once_with("valid.jwt")

--- a/uv.lock
+++ b/uv.lock
@@ -898,6 +898,7 @@ dependencies = [
 dev = [
     { name = "homeassistant" },
     { name = "pre-commit-uv" },
+    { name = "pyjwt" },
     { name = "pytest" },
     { name = "pytest-aiohttp" },
     { name = "pytest-cov" },
@@ -914,6 +915,7 @@ requires-dist = [
 dev = [
     { name = "homeassistant", specifier = "==2025.5.0" },
     { name = "pre-commit-uv", specifier = ">=4.1.5" },
+    { name = "pyjwt", specifier = ">=2.10.0" },
     { name = "pytest", specifier = "==8.4.2" },
     { name = "pytest-aiohttp", specifier = "==1.1.0" },
     { name = "pytest-cov", specifier = "==7.0.0" },


### PR DESCRIPTION
- The coordinator now decodes the JWT token to check its expiration date and only refreshes it when needed.